### PR TITLE
Fix: update github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         INTERFACESFILE: "${{ secrets.INTERFACESFILE }}"
     steps:
       - name: Checkout Classic Virtio drivers
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Configure Interfaces
         run: /Retro68-build/bin/docker-entrypoint.sh
@@ -28,7 +28,7 @@ jobs:
         run: make
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: classicvirtio-drivers-latest
           path: |
@@ -36,7 +36,7 @@ jobs:
             build/ndrv/ndrvloader
 
       - name: Prepare pre-release from artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: classicvirtio-drivers-latest
           path: archive

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload pre-release
         if: "${{ github.ref_name == 'main' }}"
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "crowbarmaster/GH-Automatic-Releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: true


### PR DESCRIPTION
This PR updates the github actions to the latest versions, and also migrates the release action from `marvinpinto/action-automatic-releases` to `crowbarmaster/GH-Automatic-Releases` in order to remove the deprecation notices.