### PR TITLE
Fix A/UX tablet panic take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 .DS_Store
+.idea

--- a/device-input.c
+++ b/device-input.c
@@ -125,8 +125,6 @@ static OSStatus finalize(DriverFinalInfo *info) {
     printf("Transport layer finalized\n");
 
     SynchronizeIO();
-    FreePages(&ppage);
-    SynchronizeIO();
     printf("Removed Successfully\n");
 
     return noErr;

--- a/device-input.c
+++ b/device-input.c
@@ -4,38 +4,37 @@
 #include <Devices.h>
 #include <DriverServices.h>
 #include <Events.h>
-#include <MixedMode.h>
-#include <Types.h>
 
 #include "allocator.h"
 #include "callout68k.h"
 #include "printf.h"
-#include "panic.h"
 #include "transport.h"
 #include "scrollwheel.h"
 #include "virtqueue.h"
 
 #include "device.h"
 
-#include <string.h>
-
 struct event {
-	int16_t type;
-	int16_t code;
-	int32_t value;
+    int16_t type;
+    int16_t code;
+    int32_t value;
 } __attribute((scalar_storage_order("little-endian")));
 
-typedef void (*GNEFilterType)(EventRecord *event, Boolean *result);
+ typedef void (*GNEFilterType)(EventRecord *event, Boolean *result);
 
-short funnel(long commandCode, void *pb);
+ short funnel(long commandCode, void *pb);
 static OSStatus finalize(DriverFinalInfo *info);
 static OSStatus initialize(DriverInitInfo *info);
 static void handleEvent(struct event e);
 static void reQueue(int bufnum);
 
+// This is a neat trick, s.t. we can store the value--which is compile-time
+// constant, but not a true const--without the compiler complaining about
+// "folding a variable-length array to constant array as an extension." --peads
+enum { MAX_SIZE = 4096 / sizeof(struct event) };
 static struct event *lpage;
 static uint32_t ppage;
-static volatile uint32_t retlens[4096 / sizeof (struct event)];
+static volatile uint32_t retlens[MAX_SIZE];
 
 DriverDescription TheDriverDescription = {
 	kTheDescriptionSignature,
@@ -52,189 +51,233 @@ OSStatus DoDriverIO(AddressSpaceID spaceID, IOCommandID cmdID,
 	IOCommandContents pb, IOCommandCode code, IOCommandKind kind) {
 	OSStatus err;
 
-	switch (code) {
-	case kInitializeCommand:
-	case kReplaceCommand:
-		err = initialize(pb.initialInfo);
-		break;
-	case kFinalizeCommand:
-	case kSupersededCommand:
-		err = finalize(pb.finalInfo);
-		break;
-	case kControlCommand:
-		err = controlErr;
-		break;
-	case kStatusCommand:
-		err = statusErr;
-		break;
-	case kOpenCommand:
-	case kCloseCommand:
-		err = noErr;
-		break;
-	case kReadCommand:
-		err = readErr;
-		break;
-	case kWriteCommand:
-		err = writErr;
-		break;
-	default:
-		err = paramErr;
-		break;
-	}
+    switch (code) {
+        case kInitializeCommand:
+        case kReplaceCommand:
+            err = initialize(pb.initialInfo);
+            break;
+        case kFinalizeCommand:
+        case kSupersededCommand:
+            err = finalize(pb.finalInfo);
+            break;
+        case kControlCommand:
+
+            switch (pb.pb->cntrlParam.csCode) {
+                case goodbye:
+                case killCode:
+                    err = finalize(pb.finalInfo);
+                    break;
+//                case 2:
+//                    TODO not sure about this yet,
+//                     but might be promising re: (re-)initializing
+//                     driver for A/UX --peads
+//                    break;
+                default:
+                    err = controlErr;
+                    break;
+            }
+            break;
+        case kStatusCommand:
+            err = statusErr;
+            break;
+        case kOpenCommand:
+        case kCloseCommand:
+            err = noErr;
+            break;
+        case kReadCommand:
+            err = readErr;
+            break;
+        case kWriteCommand:
+            err = writErr;
+            break;
+        default:
+            err = paramErr;
+            break;
+    }
 
 	// Return directly from every call
 	if (kind & kImmediateIOCommandKind) {
 		return err;
 	} else {
-		return IOCommandIsComplete(cmdID, err);
+        // Fixes complaint about the passing an `OSStatus` to a function taking
+        // `OSErr`. It'd probably be optimized out, but it might be worth
+        // considering a mask (i.e. 0xFFFF) on `err` as well. --peads
+		return IOCommandIsComplete(cmdID, (OSErr) err);
 	}
 }
 
 static OSStatus finalize(DriverFinalInfo *info) {
-	return noErr;
+
+    SynchronizeIO();
+    int nbuf = QFinal(info->refNum, MAX_SIZE);
+    if (nbuf == 0) {
+        printf("Virtqueue layer failure\n");
+        VFail();
+        return closErr;
+    }
+    SynchronizeIO();
+    printf("Virtqueue layer finalized\n");
+
+    SynchronizeIO();
+    CloseDriver(info->refNum);
+    SynchronizeIO();
+
+    if (!VFinal(&info->deviceEntry)) {
+        printf("Transport layer failure\n");
+        VFail();
+        return closErr;
+    }
+    printf("Transport layer finalized\n");
+
+    SynchronizeIO();
+    FreePages(&ppage);
+    SynchronizeIO();
+    printf("Removed Successfully\n");
+
+    return noErr;
 }
 
 static OSStatus initialize(DriverInitInfo *info) {
-	InitLog();
-	sprintf(LogPrefix, "Input(%d) ", info->refNum);
+    InitLog();
+    sprintf(LogPrefix, "Input(%d) ", info->refNum);
 
-	if (!VInit(&info->deviceEntry)) {
-		printf("Transport layer failure\n");
-		VFail();
-		return openErr;
-	};
+    if (!VInit(&info->deviceEntry)) {
+        printf("Transport layer failure\n");
+        VFail();
+        return openErr;
+    }
 
-	lpage = AllocPages(1, &ppage);
-	if (lpage == NULL) {
-		printf("Memory allocation failure\n");
-		VFail();
-		return openErr;
-	}
+    lpage = AllocPages(1, &ppage);
+    if (lpage == NULL) {
+        printf("Memory allocation failure\n");
+        VFail();
+        return openErr;
+    }
 
-	if (!VFeaturesOK()) {
-		printf("Feature negotiation failure\n");
-		VFail();
-		return openErr;
-	}
+    if (!VFeaturesOK()) {
+        printf("Feature negotiation failure\n");
+        VFail();
+        return openErr;
+    }
 
-	VDriverOK();
+    VDriverOK();
 
-	int nbuf = QInit(0, 4096 / sizeof (struct event));
-	if (nbuf == 0) {
-		printf("Virtqueue layer failure\n");
-		VFail();
-		return openErr;
-	}
+    int nbuf = QInit(0, MAX_SIZE);
+    if (nbuf == 0) {
+        printf("Virtqueue layer failure\n");
+        VFail();
+        return openErr;
+    }
 
-	for (int i=0; i<nbuf; i++) {
-		reQueue(i);
-	}
+    for (int i = 0; i < nbuf; i++) {
+        reQueue(i);
+    }
 
-	ScrollInit();
+    ScrollInit();
 
-	printf("Ready\n");
-	return noErr;
+    printf("Ready\n");
+    return noErr;
 }
 
 static void handleEvent(struct event e) {
-	enum {
-		EV_SYN = 0,
-		EV_KEY = 1,
-		EV_REL = 2,
-		EV_ABS = 3,
+    enum {
+        EV_SYN = 0,
+        EV_KEY = 1,
+        EV_REL = 2,
+        EV_ABS = 3,
 
-		BTN_LEFT = 272,
-		BTN_RIGHT = 273,
-		BTN_GEAR_DOWN = 336,
-		BTN_GEAR_UP = 337,
+        BTN_LEFT = 272,
+        BTN_RIGHT = 273,
+        BTN_GEAR_DOWN = 336,
+        BTN_GEAR_UP = 337,
 
-		REL_WHEEL = 8,
+        REL_WHEEL = 8,
 
-		ABS_X = 0,
-		ABS_Y = 1,
-	};
+        ABS_X = 0,
+        ABS_Y = 1,
+    };
 
 
-	enum {MVFLAG = 1};
+    enum { MVFLAG = 1 };
 
-	static bool knowpos;
-	static long x, y;
+    static bool knowpos;
+    static long x, y;
 
-	static int knowmask, newbtn, oldbtn;
+    static int knowmask, newbtn, oldbtn;
 
-	// Using a macOS Qemu host, each pixel of desired scroll returns both:
-	// type=EV_REL code=REL_WHEEL value=0/1
-	// type=EV_KEY code=BTN_GEAR_DOWN/BTN_GEAR_UP value=0
-	// But actually I would prefer the new-ish "REL_WHEEL_HI_RES"!
+    // Using a macOS Qemu host, each pixel of desired scroll returns both:
+    // type=EV_REL code=REL_WHEEL value=0/1
+    // type=EV_KEY code=BTN_GEAR_DOWN/BTN_GEAR_UP value=0
+    // But actually I would prefer the new-ish "REL_WHEEL_HI_RES"!
 
-	if (e.type == EV_ABS && e.code == ABS_X) {
-		knowpos = true;
-		x = e.value;
-	} else if (e.type == EV_ABS && e.code == ABS_Y) {
-		knowpos = true;
-		y = e.value;
-	} else if (e.type == 1 && e.code == BTN_LEFT) {
-		knowmask |= 1;
-		if (e.value) newbtn |= 1;
-	} else if (e.type == 1 && e.code == BTN_RIGHT) {
-		knowmask |= 2;
-		if (e.value) newbtn |= 2;
-	} else if (e.type == EV_REL && e.code == REL_WHEEL) {
-		Scroll(e.value);
-	} else if (e.type == EV_SYN) {
-		if (knowpos) {
-			// Scale to screen size (in lowmem globals)
-			unsigned long realx = x * *(int16_t *)0xc20 / 0x8000 + 1;
-			unsigned long realy = y * *(int16_t *)0xc22 / 0x8000 + 1;
+    if (e.type == EV_ABS && e.code == ABS_X) {
+        knowpos = true;
+        x = e.value;
+    } else if (e.type == EV_ABS && e.code == ABS_Y) {
+        knowpos = true;
+        y = e.value;
+    } else if (e.type == 1 && e.code == BTN_LEFT) {
+        knowmask |= 1;
+        if (e.value) newbtn |= 1;
+    } else if (e.type == 1 && e.code == BTN_RIGHT) {
+        knowmask |= 2;
+        if (e.value)  newbtn |= 2;
+    } else if (e.type == EV_REL && e.code == REL_WHEEL) {
+        Scroll(e.value);
+    } else if (e.type == EV_SYN) {
+        if (knowpos) {
+            // Scale to screen size (in lowmem globals)
+            unsigned long realx = x * *(int16_t *) 0xc20 / 0x8000 + 1;
+            unsigned long realy = y * *(int16_t *) 0xc22 / 0x8000 + 1;
 
-			unsigned long point = (realy << 16) | realx;
+            unsigned long point = (realy << 16) | realx;
 
-			*(unsigned long *)0x828 = point; // MTemp
-			*(unsigned long *)0x82c = point; // RawMouse
+            *(unsigned long *) 0x828 = point; // MTemp
+            *(unsigned long *) 0x82c = point; // RawMouse
 
-			*(char *)0x8ce = *(char *)0x8cf; // CrsrNew = CrsrCouple
+            *(char *) 0x8ce = *(char *) 0x8cf; // CrsrNew = CrsrCouple
 
-			// Call JCrsrTask to redraw the cursor immediately.
-			// Feels much more responsive than waiting for another interrupt.
-			// Could a race condition garble the cursor? Haven't seen it happen.
-			// if (*(char *)(0x174 + 7) & 1) // Uncomment to switch on shift key
-			CALL0(void, *(void **)0x8ee);
-		}
+            // Call JCrsrTask to redraw the cursor immediately.
+            // Feels much more responsive than waiting for another interrupt.
+            // Could a race condition garble the cursor? Haven't seen it happen.
+            // if (*(char *)(0x174 + 7) & 1) // Uncomment to switch on shift key
+            CALL0(void, *(void **) 0x8ee);
+        }
 
-		knowpos = false;
+        knowpos = false;
 
-		newbtn = (newbtn & knowmask) | (oldbtn & ~knowmask);
+        newbtn = (newbtn & knowmask) | (oldbtn & ~knowmask);
 
-		if ((oldbtn != 0) != (newbtn != 0)) {
-			*(unsigned char *)0x172 = newbtn ? 0 : 0x80;
+        if ((oldbtn != 0) != (newbtn != 0)) {
+            *(unsigned char *) 0x172 = newbtn ? 0 : 0x80;
 
-			EvQEl *osevent;
-			PPostEvent(newbtn ? mouseDown : mouseUp, 0, &osevent);
+            EvQEl *osevent;
+            PPostEvent(newbtn ? mouseDown : mouseUp, 0, &osevent);
 
-			// Right-click becomes control-click
-			if (newbtn & 2) {
-				osevent->evtQModifiers |= 0x1000;
-			}
-		}
+            // Right-click becomes control-click
+            if (newbtn & 2) {
+                osevent->evtQModifiers |= 0x1000;
+            }
+        }
 
-		oldbtn = newbtn;
-		knowmask = 0;
-		newbtn = 0;
-	}
+        oldbtn = newbtn;
+        knowmask = 0;
+        newbtn = 0;
+    }
 }
 
 static void reQueue(int bufnum) {
-	QSend(0, 0/*n-send*/, 1/*n-recv*/,
-		(uint32_t []){ppage + sizeof (struct event) * bufnum},
-		(uint32_t []){sizeof (struct event)},
-		&retlens[bufnum],
-		false/*wait*/);
+    QSend(0, 0/*n-send*/, 1/*n-recv*/,
+            (uint32_t[]) {ppage + sizeof(struct event) * bufnum},
+            (uint32_t[]) {sizeof(struct event)},
+            &retlens[bufnum],
+            false/*wait*/);
 }
 
-void DNotified(uint16_t q, volatile uint32_t *retlen) {
-	int bufnum = retlen - retlens;
-	handleEvent(lpage[bufnum]);
-	reQueue(bufnum);
+void DNotified( uint16_t q, volatile uint32_t *retlen) {
+    int bufnum = retlen - retlens;
+    handleEvent(lpage[bufnum]);
+    reQueue(bufnum);
 }
 
 void DConfigChange(void) {

--- a/device-input.c
+++ b/device-input.c
@@ -67,11 +67,6 @@ OSStatus DoDriverIO(AddressSpaceID spaceID, IOCommandID cmdID,
                 case killCode:
                     err = finalize(pb.finalInfo);
                     break;
-//                case 2:
-//                    TODO not sure about this yet,
-//                     but might be promising re: (re-)initializing
-//                     driver for A/UX --peads
-//                    break;
                 default:
                     err = controlErr;
                     break;

--- a/profile.c
+++ b/profile.c
@@ -17,6 +17,8 @@ and has an easy output channel (a file).
 #include "printf.h"
 
 #include "profile.h"
+// Fixes complaint due to implicit declaration of function warning. --peads
+#include "panic.h"
 
 void __cyg_profile_func_enter(void *this_fn, void *call_site);
 void __cyg_profile_func_exit(void *this_fn, void *call_site);
@@ -44,7 +46,9 @@ void InitProfile(uint32_t fid) {
 	Write9(outfid, header, 0, sizeof header - 1, NULL);
 	outseek = sizeof header - 1;
 	makeFuncTable();
-	VInstall(&timer);
+    // Fixes complaint about passing `VBLTaskq` to function taking
+    // `QElemPtr` --peads
+	VInstall((void *) &timer);
 }
 
 // thanks to -finstrument-functions

--- a/slotexec-drvrload.c
+++ b/slotexec-drvrload.c
@@ -139,7 +139,9 @@ void exec(struct SEBlock *pb) {
 	HLock(hdl);
 	struct drvr *drvr = (struct drvr *)*hdl;
 
-	drvr->flags = dNeedLockMask|dStatEnableMask|dCtlEnableMask|dWritEnableMask|dReadEnableMask;
+    // Added goodbye mask, s.t. it can be finalized on starting A/UX --peads
+	drvr->flags = dNeedLockMask|dStatEnableMask|dCtlEnableMask|dWritEnableMask|dReadEnableMask
+            |dNeedGoodByeMask;
 	drvr->open = drvr->prime = drvr->ctl = drvr->status = drvr->close = offsetof(struct drvr, code);
 
 	const char *name = slotStruct(slot, srsrc, sRsrcName, 0);

--- a/transport-classic.c
+++ b/transport-classic.c
@@ -51,25 +51,13 @@ static struct SlotIntQElement slotInterruptBackstop = {
 bool VFinal(RegEntryID *id) {
     UInt32 slotnum = id->contents[0];
 
-    if (device->magicValue != 0x74726976) return false;
+    device->status = 0;
     SynchronizeIO();
-
-    if (device->version != 2) return false;
-    SynchronizeIO();
-
-    pic->enable = 0;
-    SynchronizeIO();
-    pic->disable = 0xffffffff;
-    SynchronizeIO();
-    printf("Device disabled\n");
+    while (device->status) {} // await 0
 
     printf("Slot removed: 0x%04X\n", SIntRemove(&slotInterrupt, slotnum));
     printf("Slot backstop removed: 0x%04X\n", SIntRemove(&slotInterruptBackstop, slotnum));
     SynchronizeIO();
-
-    device->status = 0;
-    SynchronizeIO();
-    while (device->status) {} // await 0
 
     return true;
 }

--- a/transport-classic.c
+++ b/transport-classic.c
@@ -48,11 +48,38 @@ static struct SlotIntQElement slotInterruptBackstop = {
 	.sqAddr = CALLIN68K_C_ARG0_GLOBDEF(interruptCompleteStub),
 };
 
+bool VFinal(RegEntryID *id) {
+    UInt32 slotnum = id->contents[0];
+
+    if (device->magicValue != 0x74726976) return false;
+    SynchronizeIO();
+
+    if (device->version != 2) return false;
+    SynchronizeIO();
+
+    pic->enable = 0;
+    SynchronizeIO();
+    pic->disable = 0xffffffff;
+    SynchronizeIO();
+    printf("Device disabled\n");
+
+    printf("Slot removed: 0x%04X\n", SIntRemove(&slotInterrupt, slotnum));
+    printf("Slot backstop removed: 0x%04X\n", SIntRemove(&slotInterruptBackstop, slotnum));
+    SynchronizeIO();
+
+    device->status = 0;
+    SynchronizeIO();
+    while (device->status) {} // await 0
+
+    return true;
+}
+
 // returns true for OK
 bool VInit(RegEntryID *id) {
+    // Fixes complaint about storing unsigned int in a signed int type. --peads
 	// Work around a shortcoming in global initialisation
-	int slotnum = id->contents[0];
-	int devindex = id->contents[1];
+    UInt32 slotnum = id->contents[0];
+    UInt32 devindex = id->contents[1];
 
 	pic = (void *)(0xf0000000 + 0x1000000*slotnum);
 	device = (void *)(0xf0000000 + 0x1000000*slotnum + 0x200*(devindex+1));
@@ -76,10 +103,10 @@ bool VInit(RegEntryID *id) {
 	while (device->status) {} // wait till 0
 
 	// 2. Set the ACKNOWLEDGE status bit: the guest OS has noticed the device.
-	device->status = 1;
-	SynchronizeIO();
+    device->status = 1;
+    SynchronizeIO();
 
-	// 3. Set the DRIVER status bit: the guest OS knows how to drive the device.
+    // 3. Set the DRIVER status bit: the guest OS knows how to drive the device.
 	device->status = 1 | 2;
 	SynchronizeIO();
 
@@ -102,7 +129,7 @@ bool VInit(RegEntryID *id) {
 // Negotiate features
 bool VGetDevFeature(uint32_t number) {
 	SynchronizeIO();
-	device->deviceFeaturesSel = number / 32;
+	device->deviceFeaturesSel = number >> 5;
 	SynchronizeIO();
 	return (device->deviceFeatures >> (number % 32)) & 1;
 }
@@ -112,7 +139,7 @@ void VSetFeature(uint32_t number, bool val) {
 	uint32_t bits;
 
 	SynchronizeIO();
-	device->driverFeaturesSel = number / 32;
+	device->driverFeaturesSel = number >> 5;
 	SynchronizeIO();
 
 	bits = device->driverFeatures;

--- a/transport-ndrv.c
+++ b/transport-ndrv.c
@@ -33,6 +33,11 @@ static bool gSuppressNotification;
 static InterruptMemberNumber interrupt(InterruptSetMember ist, void *refCon, uint32_t intCount);
 static void findLogicalBARs(RegEntryID *pciDevice, void *barArray[6]);
 
+bool VFinal(RegEntryID *dev) {
+    // stub
+    return true;
+}
+
 // For PCI devices, the void pointer is a RegEntryIDPtr.
 // Leave the device in DRIVER status.
 bool VInit(RegEntryID *dev) {

--- a/transport.h
+++ b/transport.h
@@ -14,6 +14,7 @@
 // The void pointer somehow identifies the PCI or MMIO device
 // returns true for OK
 bool VInit(RegEntryID *dev);
+bool VFinal(RegEntryID *dev);
 
 // Sets these globals
 extern void *VConfig;

--- a/virtqueue.c
+++ b/virtqueue.c
@@ -36,6 +36,23 @@ static void poll(uint16_t q);
 
 static struct virtq queues[MAX_VQ];
 
+uint16_t QFinal(uint16_t q, uint16_t max_size) {
+    if (q >= MAX_VQ) return 0;
+
+    uint16_t size = max_size;
+    if (size > MAX_RING) size = MAX_RING;
+    if (size > VQueueMaxSize(q)) size = VQueueMaxSize(q);
+
+    FreePages(queues[q].desc);
+
+    queues[q].size = size - 1;
+
+    // Mark all descriptors free
+    for (int i=0; i<queues[q].size; i++) queues[q].desc[i].next = 0xffff;
+
+    return queues[q].size;
+}
+
 uint16_t QInit(uint16_t q, uint16_t max_size) {
 	if (q >= MAX_VQ) return 0;
 

--- a/virtqueue.c
+++ b/virtqueue.c
@@ -39,18 +39,9 @@ static struct virtq queues[MAX_VQ];
 uint16_t QFinal(uint16_t q, uint16_t max_size) {
     if (q >= MAX_VQ) return 0;
 
-    uint16_t size = max_size;
-    if (size > MAX_RING) size = MAX_RING;
-    if (size > VQueueMaxSize(q)) size = VQueueMaxSize(q);
-
     FreePages(queues[q].desc);
 
-    queues[q].size = size - 1;
-
-    // Mark all descriptors free
-    for (int i=0; i<queues[q].size; i++) queues[q].desc[i].next = 0xffff;
-
-    return queues[q].size;
+    return --queues[q].size;
 }
 
 uint16_t QInit(uint16_t q, uint16_t max_size) {

--- a/virtqueue.h
+++ b/virtqueue.h
@@ -8,6 +8,7 @@
 
 // Create a descriptor ring for this virtqueue, return actual size
 uint16_t QInit(uint16_t q, uint16_t max_size);
+uint16_t QFinal(uint16_t q, uint16_t max_size);
 
 // Never blocks, just panics if not enough descriptors available
 void QSend(


### PR DESCRIPTION
Successfully removes driver when A/UX boots. Now to reconnect it afterwards.

Successfully reattaches, but does not yet work.

incremental

removed unnecessary debug info, reverted changed debug outputs

Formatted for readability

Removed cruft. Added another case where a different control signal value is sent by A/UX to the device

Added heap init flag to slotexec, s.t. the device now receives the signal when, for example, the machine goes down for reboot, and it can then handle the finalization correctly. Removed extraneous cases in the switch since it appears they are not invoked. It now comes back up properly after a reboot, but still no dice on after starting A/UX.

Reverted having moved InitLog for debugging purposes. Added it to finalize incase it hasn't already been so.

Removed extraneous flag for kDriverSupportDMSuspendAndResume, which is not used. Cleaned up doubly-applied gcc unused indicator.

Looks like the reboot issue in os8 was a sync problem. So, added an extra IO sync. Removed unused local in VFinal.

Added more verbose debug message. Fixed incorrect return value in finalize.

Changed control determination to use more accurate consts from the API. Removed unnecessary debug output(s). More reverse-engineering/rtfm of the dev docs trying to get A/UX to recognize the tablet.

Revert mask I added on the code switch

Revert pointless changes. Justify changes with commentary. Sqaush commits